### PR TITLE
Feature added: Restrict Hungry Animals to an area

### DIFF
--- a/Languages/English/Keyed/Manager_Keyed.xml
+++ b/Languages/English/Keyed/Manager_Keyed.xml
@@ -167,6 +167,10 @@
   <FML.Training>Training</FML.Training>
   <FML.RestrictToArea>Restrict animals to area?</FML.RestrictToArea>
   <FML.RestrictToArea.Tip>Restrict animals to a specific area, optionally separated by gender and lifestage</FML.RestrictToArea.Tip>
+  <FML.RestrictToHungryArea>Restrict hungry animals</FML.RestrictToHungryArea>
+  <FML.RestrictToHungryArea.Tip>Restrict hungry animals to a specific area, optionally separated by gender and lifestage, as long as they are not restricted animals marked for slaughter.</FML.RestrictToHungryArea.Tip>
+  <FML.SendToHungryAreaMaximumFoodNeed.Label>Animal Food Need</FML.SendToHungryAreaMaximumFoodNeed.Label>
+  <FML.SendToHungryAreaMaximumFoodNeed.Tip>An animal whose food need is below or equal to this value will be restricted to this area.</FML.SendToHungryAreaMaximumFoodNeed.Tip>
   <FML.ButcherExcess>Butcher excess livestock</FML.ButcherExcess>
   <FML.ButcherExcess.Tip>Should excess livestock be butchered for meat?</FML.ButcherExcess.Tip>
   <FML.ButcherTrained>Trained</FML.ButcherTrained>
@@ -205,7 +209,7 @@
   <FM.Livestock.DisabledBecauseNoTrainingSet>Disabled because no training target is set.</FM.Livestock.DisabledBecauseNoTrainingSet>
   <FM.Livestock.CannotTrainTooSmall>{0} are too small to train this.</FM.Livestock.CannotTrainTooSmall>
 
-  <!-- following -->
+    <!-- following -->
   <FM.Livestock.FollowHeader>Following</FM.Livestock.FollowHeader>
   <FM.Livestock.MasterDefault>Assign master(s)</FM.Livestock.MasterDefault>
   <FM.Livestock.MasterDefault.Tip>Assign animals to a specific master, or to groups of colonists. May overwrite user settings when enabled.</FM.Livestock.MasterDefault.Tip>

--- a/Languages/English/Keyed/Manager_Keyed.xml
+++ b/Languages/English/Keyed/Manager_Keyed.xml
@@ -209,7 +209,7 @@
   <FM.Livestock.DisabledBecauseNoTrainingSet>Disabled because no training target is set.</FM.Livestock.DisabledBecauseNoTrainingSet>
   <FM.Livestock.CannotTrainTooSmall>{0} are too small to train this.</FM.Livestock.CannotTrainTooSmall>
 
-    <!-- following -->
+  <!-- following -->
   <FM.Livestock.FollowHeader>Following</FM.Livestock.FollowHeader>
   <FM.Livestock.MasterDefault>Assign master(s)</FM.Livestock.MasterDefault>
   <FM.Livestock.MasterDefault.Tip>Assign animals to a specific master, or to groups of colonists. May overwrite user settings when enabled.</FM.Livestock.MasterDefault.Tip>

--- a/Source/Helpers/Utilities.cs
+++ b/Source/Helpers/Utilities.cs
@@ -327,6 +327,22 @@ namespace FluffyManager
             DrawToggle( rect, label, tooltip, checkOn, !checkOn, on, off, expensive, size, margin, wrap );
         }
 
+        public static void DrawSlider(Rect rect, string label, string tooltip, ref float value, float size = 5*SmallIconSize,
+                                       float margin = Margin, bool wrap = true)
+        {
+            // set up rects
+            var labelRect = rect;
+            var sliderRect = new Rect(rect.xMax - size - margin, 0f, size, labelRect.height/2f);
+            labelRect.xMax = sliderRect.xMin - Margin / 2f;           
+            // finetune rects
+            sliderRect = sliderRect.CenteredOnYIn(labelRect);
+            // draw label
+            Label(rect, label, TextAnchor.MiddleLeft, GameFont.Small, margin: margin, wrap: wrap);
+            // tooltip
+            if (!tooltip.NullOrEmpty()) TooltipHandler.TipRegion(rect, tooltip );
+            // draw slider
+            value = Widgets.HorizontalSlider(sliderRect, value, 0f, 1f, true, String.Format("{0:P0}", value)); // GUI.HorizontalSlider(sliderRect, value, 0f, 1f);
+        }
 
         public static void DrawToggle( Rect rect, string label, string tooltip, bool checkOn, bool checkOff, Action on,
                                        Action off, bool expensive = false, float size = SmallIconSize,

--- a/Source/ManagerJobs/ManagerJob_Livestock.cs
+++ b/Source/ManagerJobs/ManagerJob_Livestock.cs
@@ -158,7 +158,8 @@ namespace FluffyManager
             Scribe_Values.Look( ref ButcherPregnant, "ButcherPregnant" );
             Scribe_Values.Look( ref ButcherBonded, "ButcherBonded" );
             Scribe_Values.Look( ref RestrictToArea, "RestrictToArea" );
-            Scribe_Values.Look(ref RestrictToHungryArea, "RestrictToHungryArea", false);
+            Scribe_Values.Look( ref RestrictToHungryArea, "RestrictToHungryArea", false);
+            Scribe_Values.Look( ref SendToHungryAreaMaximumFoodNeed, "SendToHungryAreaMaximumFoodNeed", 0.01f);
             Scribe_Values.Look( ref SendToSlaughterArea, "SendToSlaughterArea" );
             Scribe_Values.Look( ref SendToTrainingArea, "SendToTrainingArea" );
             Scribe_Values.Look( ref TryTameMore, "TryTameMore" );

--- a/Source/ManagerJobs/ManagerJob_Livestock.cs
+++ b/Source/ManagerJobs/ManagerJob_Livestock.cs
@@ -31,6 +31,9 @@ namespace FluffyManager
         public                  bool              RespectBonds = true;
         public                  List<Area>        RestrictArea;
         public                  bool              RestrictToArea;
+        public                  List<Area>        RestrictHungryArea;
+        public                  bool              RestrictToHungryArea;
+        public                  float             SendToHungryAreaMaximumFoodNeed;
         public                  bool              SendToSlaughterArea;
         public                  bool              SendToTrainingArea;
         public                  bool              SetFollow;
@@ -71,6 +74,11 @@ namespace FluffyManager
             TameArea       = null;
             RestrictToArea = false;
             RestrictArea   = Utilities_Livestock.AgeSexArray.Select( k => (Area) null ).ToList();
+
+            // set hungry animals areas for restriction
+            RestrictToHungryArea = false;
+            SendToHungryAreaMaximumFoodNeed = 0.01f;
+            RestrictHungryArea = Utilities_Livestock.AgeSexArray.Select(k => (Area)null).ToList();
 
             // set up sending animals designated for slaughter to an area (freezer)
             SendToSlaughterArea = false;
@@ -141,6 +149,7 @@ namespace FluffyManager
             Scribe_References.Look( ref Master, "Master" );
             Scribe_References.Look( ref Trainer, "Trainer" );
             Scribe_Collections.Look( ref RestrictArea, "AreaRestrictions", LookMode.Reference );
+            Scribe_Collections.Look(ref RestrictHungryArea, "HungryAreaRestrictions", LookMode.Reference);
             Scribe_Deep.Look( ref Trigger, "trigger", manager );
             Scribe_Deep.Look( ref Training, "Training" );
             Scribe_Deep.Look( ref _history, "History" );
@@ -149,6 +158,7 @@ namespace FluffyManager
             Scribe_Values.Look( ref ButcherPregnant, "ButcherPregnant" );
             Scribe_Values.Look( ref ButcherBonded, "ButcherBonded" );
             Scribe_Values.Look( ref RestrictToArea, "RestrictToArea" );
+            Scribe_Values.Look(ref RestrictToHungryArea, "RestrictToHungryArea", false);
             Scribe_Values.Look( ref SendToSlaughterArea, "SendToSlaughterArea" );
             Scribe_Values.Look( ref SendToTrainingArea, "SendToTrainingArea" );
             Scribe_Values.Look( ref TryTameMore, "TryTameMore" );
@@ -221,6 +231,12 @@ namespace FluffyManager
                             p.playerSettings.AreaRestriction = SlaughterArea;
                         }
 
+                        // hungry
+                        else if (RestrictToHungryArea && p.needs.food.CurLevelPercentage <= SendToHungryAreaMaximumFoodNeed)
+                        {
+                            actionTaken = true;
+                            p.playerSettings.AreaRestriction = RestrictHungryArea[i];
+                        }
                         // training
                         else if ( SendToTrainingArea && p.training.NextTrainableToTrain() != null )
                         {

--- a/Source/ManagerTabs/ManagerTab_Livestock.cs
+++ b/Source/ManagerTabs/ManagerTab_Livestock.cs
@@ -199,7 +199,7 @@ namespace FluffyManager
             DoCountField( countRects[1, 2], AgeAndSex.AdultMale );
             DoCountField( countRects[2, 1], AgeAndSex.JuvenileFemale );
             DoCountField( countRects[2, 2], AgeAndSex.JuvenileMale );
-            
+
             return 3 * ListEntryHeight;
         }
 

--- a/Source/ManagerTabs/ManagerTab_Livestock.cs
+++ b/Source/ManagerTabs/ManagerTab_Livestock.cs
@@ -199,7 +199,7 @@ namespace FluffyManager
             DoCountField( countRects[1, 2], AgeAndSex.AdultMale );
             DoCountField( countRects[2, 1], AgeAndSex.JuvenileFemale );
             DoCountField( countRects[2, 2], AgeAndSex.JuvenileMale );
-
+            
             return 3 * ListEntryHeight;
         }
 
@@ -361,44 +361,8 @@ namespace FluffyManager
 
             if ( _selectedCurrent.RestrictToArea )
             {
-                // area selectors table
-                // set up a 3x3 table of rects
-                var     cols    = 3;
-                var     fifth   = width / 5;
-                float[] widths  = {fifth, fifth        * 2, fifth * 2};
-                float[] heights = {ListEntryHeight * 2 / 3, ListEntryHeight, ListEntryHeight};
-
-                var areaRects = new Rect[cols, cols];
-                for ( var x = 0; x < cols; x++ )
-                    for ( var y = 0; y < cols; y++ )
-                        areaRects[x, y] = new Rect(
-                            widths.Take( x ).Sum(),
-                            pos.y + heights.Take( y ).Sum(),
-                            widths[x],
-                            heights[y] );
-
-                // headers
-                Label( areaRects[1, 0], Gender.Female.ToString(), TextAnchor.LowerCenter, GameFont.Tiny );
-                Label( areaRects[2, 0], Gender.Male.ToString(), TextAnchor.LowerCenter, GameFont.Tiny );
-                Label( areaRects[0, 1], "FML.Adult".Translate(), TextAnchor.MiddleRight, GameFont.Tiny );
-                Label( areaRects[0, 2], "FML.Juvenile".Translate(), TextAnchor.MiddleRight, GameFont.Tiny );
-
-                // do the selectors
-                _selectedCurrent.RestrictArea[0] = AreaAllowedGUI.DoAllowedAreaSelectors( areaRects[1, 1],
-                                                                                          _selectedCurrent.RestrictArea[
-                                                                                              0], manager, Margin );
-                _selectedCurrent.RestrictArea[1] = AreaAllowedGUI.DoAllowedAreaSelectors( areaRects[2, 1],
-                                                                                          _selectedCurrent.RestrictArea[
-                                                                                              1], manager, Margin );
-                _selectedCurrent.RestrictArea[2] = AreaAllowedGUI.DoAllowedAreaSelectors( areaRects[1, 2],
-                                                                                          _selectedCurrent.RestrictArea[
-                                                                                              2], manager, Margin );
-                _selectedCurrent.RestrictArea[3] = AreaAllowedGUI.DoAllowedAreaSelectors( areaRects[2, 2],
-                                                                                          _selectedCurrent.RestrictArea[
-                                                                                              3], manager, Margin );
-
-                Text.Anchor =  TextAnchor.UpperLeft; // DoAllowedAreaMode leaves the anchor in an incorrect state.
-                pos.y       += 3 * ListEntryHeight;
+                 DrawAreaSelectorPerGenderAndAge(pos, width, ref _selectedCurrent.RestrictArea);
+                pos.y += 3 * ListEntryHeight;
             }
 
             var sendToSlaughterAreaRect = new Rect( pos.x, pos.y, width, ListEntryHeight );
@@ -424,6 +388,29 @@ namespace FluffyManager
                 Label( sendToSlaughterAreaRect, "FML.SendToSlaughterArea".Translate(),
                        "FM.Livestock.DisabledBecauseSlaughterExcessDisabled".Translate(), TextAnchor.MiddleLeft,
                        color: Color.grey );
+            }
+
+            // restrict to hungry area
+            var RestrictHungryAreaRect = new Rect(pos.x, pos.y, width, ListEntryHeight);
+
+            DrawToggle(RestrictHungryAreaRect,
+                        "FML.RestrictToHungryArea".Translate(),
+                        "FML.RestrictToHungryArea.Tip".Translate(),
+                        ref _selectedCurrent.RestrictToHungryArea);
+            pos.y += ListEntryHeight;
+            if (_selectedCurrent.RestrictToHungryArea)
+            {
+                if (_selectedCurrent.RestrictHungryArea.Count != _selectedCurrent.RestrictArea.Count)
+                {
+                    _selectedCurrent.RestrictHungryArea = Utilities_Livestock.AgeSexArray.Select(k => (Area)null).ToList();
+                }
+                DrawAreaSelectorPerGenderAndAge(pos, width, ref _selectedCurrent.RestrictHungryArea);
+                pos.y += 3 * ListEntryHeight;
+                var HungryAreaFoodFullness = new Rect(pos.x, pos.y, width, ListEntryHeight);
+                HungryAreaFoodFullness.xMin += 3 * Margin;
+                DrawSlider(HungryAreaFoodFullness, "FML.SendToHungryAreaMaximumFoodNeed.Label".Translate(), "FML.SendToHungryAreaMaximumFoodNeed.Tip".Translate(),
+                    ref _selectedCurrent.SendToHungryAreaMaximumFoodNeed);
+                pos.y += ListEntryHeight;
             }
 
             var sendToTrainingAreaRect = new Rect( pos.x, pos.y, width, ListEntryHeight );
@@ -452,6 +439,41 @@ namespace FluffyManager
             }
 
             return pos.y - start.y;
+        }
+
+
+
+        private void DrawAreaSelectorPerGenderAndAge(Vector2 pos, float width, ref List<Area> restrictArea)
+        {
+            // area selectors table
+            // set up a 3x3 table of rects
+            var cols = 3;
+            var fifth = width / 5;
+            float[] widths = { fifth, fifth * 2, fifth * 2 };
+            float[] heights = { ListEntryHeight * 2 / 3, ListEntryHeight, ListEntryHeight };
+
+            var areaRects = new Rect[cols, cols];
+            for (var x = 0; x < cols; x++)
+                for (var y = 0; y < cols; y++)
+                    areaRects[x, y] = new Rect(
+                        widths.Take(x).Sum(),
+                        pos.y + heights.Take(y).Sum(),
+                        widths[x],
+                        heights[y]);
+
+            // headers
+            Label(areaRects[1, 0], Gender.Female.ToString(), TextAnchor.LowerCenter, GameFont.Tiny);
+            Label(areaRects[2, 0], Gender.Male.ToString(), TextAnchor.LowerCenter, GameFont.Tiny);
+            Label(areaRects[0, 1], "FML.Adult".Translate(), TextAnchor.MiddleRight, GameFont.Tiny);
+            Label(areaRects[0, 2], "FML.Juvenile".Translate(), TextAnchor.MiddleRight, GameFont.Tiny);
+
+            // do the selectors
+            restrictArea[0] = AreaAllowedGUI.DoAllowedAreaSelectors(areaRects[1, 1], restrictArea[0], manager, Margin);
+            restrictArea[1] = AreaAllowedGUI.DoAllowedAreaSelectors(areaRects[2, 1], restrictArea[1], manager, Margin);
+            restrictArea[2] = AreaAllowedGUI.DoAllowedAreaSelectors(areaRects[1, 2], restrictArea[2], manager, Margin);
+            restrictArea[3] = AreaAllowedGUI.DoAllowedAreaSelectors(areaRects[2, 2], restrictArea[3], manager, Margin);
+
+            Text.Anchor = TextAnchor.UpperLeft; // DoAllowedAreaMode leaves the anchor in an incorrect state.
         }
 
         private float DrawTrainingSection( Vector2 pos, float width )


### PR DESCRIPTION
A new area restriction added to send hungry animals to a specific area (separated by gender and age).
The "food need" limit can be adjusted such that only hungry enough animals are sent there.

The idea behind is to have a bit more control in certain cases, like for example:
- If animals are waiting to be tamed (and potentially in the future to be milked or sheared) it happens sometimes that the handler is not available, and the animals get stuck in an area where they either starve or need to be provided food (which would come from the winter reserves).
- It allows to have all animals in a central place and only go out to eat some grass and then come back. Currently you can sort of do this with sleeping spots, but during sleep animals cannot be handled and during the day they roam free far away from the barn.
- You can have animals in a particular area (generally), but have an emergency food stash for hard times. The animals would go there if needed.
- You can have wargs hauling food to the freezer, but prevent them from eating the meat there, because as soon as they are a bit hungry they are sent to a special freezer to feed on corpses, etc.